### PR TITLE
Add default button overlay (And Color stuff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You're all set, now hit build.
     
 ### Known Issues
 Since this is in very early stages of development a lot of things don't quite work properly yet:
-* In-app settings (you can edit the settings at [internal_storage]/citra-emu/config/config.ini);
+
 * Colors in games (since GLES doesn't support BGR color ordering, the color channels may be inverted);
 * Since this is based on an older version of Citra, bugs solved on newer versions of Citra may still be present.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ You're all set, now hit build.
     
 ### Known Issues
 Since this is in very early stages of development a lot of things don't quite work properly yet:
-
 * Colors in games (since GLES doesn't support BGR color ordering, the color channels may be inverted);
 * Since this is based on an older version of Citra, bugs solved on newer versions of Citra may still be present.
 

--- a/app/src/main/java/org/citra/citra_android/overlay/InputOverlay.java
+++ b/app/src/main/java/org/citra/citra_android/overlay/InputOverlay.java
@@ -976,69 +976,69 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
   {
     mIsInEditMode = isInEditMode;
   }
-      private void defaultOverlay()
-    {
-        // It's possible that a user has created their overlay before this was added
-        // Only change the overlay if the 'A' button is not in the upper corner.
-        // GameCube
-        if (mPreferences.getFloat(ButtonType.BUTTON_A + "-X", 0f) == 0f)
-        {
-            N3DS_DefaultOverlay();
-        }
-        SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
-        sPrefsEditor.putBoolean("OverlayInit", true);
-        sPrefsEditor.apply();
-    }
-	private void N3DS_DefaultOverlay()
-    {
-        SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
-        // Get screen size
-        Display display = ((Activity) getContext()).getWindowManager().getDefaultDisplay();
-        DisplayMetrics outMetrics = new DisplayMetrics();
-        display.getMetrics(outMetrics);
-        float maxX = outMetrics.heightPixels;
-        float maxY = outMetrics.widthPixels;
-        // Height and width changes depending on orientation. Use the larger value for height.
-        if (maxY > maxX)
-        {
-            float tmp = maxX;
-            maxX = maxY;
-            maxY = tmp;
-        }
-        Resources res = getResources();
-        // Each value is a percent from max X/Y stored as an int. Have to bring that value down
-        // to a decimal before multiplying by MAX X/Y.
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_A + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_A_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_A + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_A_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_B + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_B_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_B + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_B_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_X + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_X_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_X + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_X_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_Y + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_Y_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_Y + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_Y_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZL + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZL_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZL + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZL_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZR + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZR_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZR + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZR_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_DPAD_UP + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_UP_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_DPAD_UP + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_UP_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_L + "-X", (((float)res.getInteger(R.integer.N3DS_TRIGGER_L_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_L + "-Y", (((float)res.getInteger(R.integer.N3DS_TRIGGER_L_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_R + "-X", (((float)res.getInteger(R.integer.N3DS_TRIGGER_R_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_R + "-Y", (((float)res.getInteger(R.integer.N3DS_TRIGGER_R_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_START + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_START_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_START + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_START_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_SELECT + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_SELECT_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_SELECT + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_SELECT_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_HOME + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_HOME_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_HOME + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_HOME_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_C + "-X", (((float)res.getInteger(R.integer.N3DS_STICK_C_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_C + "-Y", (((float)res.getInteger(R.integer.N3DS_STICK_C_Y) / 1000) * maxY));
-        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_LEFT + "-X", (((float)res.getInteger(R.integer.N3DS_STICK_MAIN_X) / 1000) * maxX));
-        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_LEFT + "-Y", (((float)res.getInteger(R.integer.N3DS_STICK_MAIN_Y) / 1000) * maxY));
-        // We want to commit right away, otherwise the overlay could load before this is saved.
-        sPrefsEditor.commit();
-    }
+  private void defaultOverlay()
+  {
+    // It's possible that a user has created their overlay before this was added
+    // Only change the overlay if the 'A' button is not in the upper corner.
+    // GameCube
+    if (mPreferences.getFloat(ButtonType.BUTTON_A + "-X", 0f) == 0f)
+      {
+        N3DS_DefaultOverlay();
+      }
+    SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
+    sPrefsEditor.putBoolean("OverlayInit", true);
+    sPrefsEditor.apply();
+  }
+  private void N3DS_DefaultOverlay()
+  {
+    SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
+    // Get screen size
+    Display display = ((Activity) getContext()).getWindowManager().getDefaultDisplay();
+    DisplayMetrics outMetrics = new DisplayMetrics();
+    display.getMetrics(outMetrics);
+    float maxX = outMetrics.heightPixels;
+    float maxY = outMetrics.widthPixels;
+    // Height and width changes depending on orientation. Use the larger value for height.
+    if (maxY > maxX)
+     {
+        float tmp = maxX;
+        maxX = maxY;
+        maxY = tmp;
+     }
+    Resources res = getResources();
+    // Each value is a percent from max X/Y stored as an int. Have to bring that value down
+    // to a decimal before multiplying by MAX X/Y.
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_A + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_A_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_A + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_A_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_B + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_B_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_B + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_B_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_X + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_X_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_X + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_X_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_Y + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_Y_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_Y + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_Y_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZL + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZL_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZL + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZL_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZR + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZR_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZR + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZR_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_DPAD_UP + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_UP_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_DPAD_UP + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_UP_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_L + "-X", (((float)res.getInteger(R.integer.N3DS_TRIGGER_L_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_L + "-Y", (((float)res.getInteger(R.integer.N3DS_TRIGGER_L_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_R + "-X", (((float)res.getInteger(R.integer.N3DS_TRIGGER_R_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_R + "-Y", (((float)res.getInteger(R.integer.N3DS_TRIGGER_R_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_START + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_START_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_START + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_START_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_SELECT + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_SELECT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_SELECT + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_SELECT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_HOME + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_HOME_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_HOME + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_HOME_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_STICK_C + "-X", (((float)res.getInteger(R.integer.N3DS_STICK_C_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_STICK_C + "-Y", (((float)res.getInteger(R.integer.N3DS_STICK_C_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.N3DS_STICK_LEFT + "-X", (((float)res.getInteger(R.integer.N3DS_STICK_MAIN_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.N3DS_STICK_LEFT + "-Y", (((float)res.getInteger(R.integer.N3DS_STICK_MAIN_Y) / 1000) * maxY));
+    // We want to commit right away, otherwise the overlay could load before this is saved.
+    sPrefsEditor.commit();
+  }
   public boolean isInEditMode()
   {
     return mIsInEditMode;

--- a/app/src/main/java/org/citra/citra_android/overlay/InputOverlay.java
+++ b/app/src/main/java/org/citra/citra_android/overlay/InputOverlay.java
@@ -989,7 +989,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
         sPrefsEditor.putBoolean("OverlayInit", true);
         sPrefsEditor.apply();
     }
-private void N3DS_DefaultOverlay()
+	private void N3DS_DefaultOverlay()
     {
         SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
         // Get screen size

--- a/app/src/main/java/org/citra/citra_android/overlay/InputOverlay.java
+++ b/app/src/main/java/org/citra/citra_android/overlay/InputOverlay.java
@@ -6,6 +6,7 @@
 
 package org.citra.citra_android.overlay;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
@@ -20,6 +21,7 @@ import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
+import android.view.Display;
 import android.view.View.OnTouchListener;
 
 import org.citra.citra_android.NativeLibrary;
@@ -79,7 +81,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     super(context, attrs);
 
     mPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
-
+    	if(!mPreferences.getBoolean("OverlayInit", false))
+	    defaultOverlay();
     // Load the controls.
     refreshControls();
 
@@ -782,42 +785,11 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     switch (buttonId)
     {
-      case ButtonType.BUTTON_A:
-      case ButtonType.WIIMOTE_BUTTON_B:
-      case ButtonType.NUNCHUK_BUTTON_Z:
-        scale = 0.2f;
-        break;
-      case ButtonType.BUTTON_X:
-      case ButtonType.BUTTON_Y:
-        scale = 0.175f;
-        break;
-      case ButtonType.BUTTON_Z:
-      case ButtonType.TRIGGER_L:
-      case ButtonType.TRIGGER_R:
-        scale = 0.225f;
-        break;
-      case ButtonType.BUTTON_START:
-        scale = 0.075f;
-        break;
-      case ButtonType.WIIMOTE_BUTTON_1:
-      case ButtonType.WIIMOTE_BUTTON_2:
-        scale = 0.0875f;
-        break;
-      case ButtonType.WIIMOTE_BUTTON_PLUS:
-      case ButtonType.WIIMOTE_BUTTON_MINUS:
-      case ButtonType.WIIMOTE_BUTTON_HOME:
-      case ButtonType.CLASSIC_BUTTON_PLUS:
-      case ButtonType.CLASSIC_BUTTON_MINUS:
-      case ButtonType.CLASSIC_BUTTON_HOME:
       case ButtonType.N3DS_BUTTON_HOME:
       case ButtonType.N3DS_BUTTON_START:
       case ButtonType.N3DS_BUTTON_SELECT:
         scale = 0.0625f;
         break;
-      case ButtonType.CLASSIC_TRIGGER_L:
-      case ButtonType.CLASSIC_TRIGGER_R:
-      case ButtonType.CLASSIC_BUTTON_ZL:
-      case ButtonType.CLASSIC_BUTTON_ZR:
       case ButtonType.N3DS_TRIGGER_L:
       case ButtonType.N3DS_TRIGGER_R:
       case ButtonType.N3DS_BUTTON_ZL:
@@ -891,10 +863,6 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     switch (buttonUp)
     {
-      case ButtonType.BUTTON_UP:
-        scale = 0.2375f;
-        break;
-      case ButtonType.CLASSIC_DPAD_UP:
       case ButtonType.N3DS_DPAD_UP:
         scale = 0.275f;
         break;
@@ -978,7 +946,6 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     switch (joystick)
     {
-      case ButtonType.STICK_C:
       case ButtonType.N3DS_STICK_C:
         innerScale = 1.833f;
         break;
@@ -1009,7 +976,69 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
   {
     mIsInEditMode = isInEditMode;
   }
-
+      private void defaultOverlay()
+    {
+        // It's possible that a user has created their overlay before this was added
+        // Only change the overlay if the 'A' button is not in the upper corner.
+        // GameCube
+        if (mPreferences.getFloat(ButtonType.BUTTON_A + "-X", 0f) == 0f)
+        {
+            N3DS_DefaultOverlay();
+        }
+        SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
+        sPrefsEditor.putBoolean("OverlayInit", true);
+        sPrefsEditor.apply();
+    }
+private void N3DS_DefaultOverlay()
+    {
+        SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
+        // Get screen size
+        Display display = ((Activity) getContext()).getWindowManager().getDefaultDisplay();
+        DisplayMetrics outMetrics = new DisplayMetrics();
+        display.getMetrics(outMetrics);
+        float maxX = outMetrics.heightPixels;
+        float maxY = outMetrics.widthPixels;
+        // Height and width changes depending on orientation. Use the larger value for height.
+        if (maxY > maxX)
+        {
+            float tmp = maxX;
+            maxX = maxY;
+            maxY = tmp;
+        }
+        Resources res = getResources();
+        // Each value is a percent from max X/Y stored as an int. Have to bring that value down
+        // to a decimal before multiplying by MAX X/Y.
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_A + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_A_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_A + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_A_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_B + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_B_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_B + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_B_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_X + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_X_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_X + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_X_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_Y + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_Y_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_Y + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_Y_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZL + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZL_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZL + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZL_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZR + "-X",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZR_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_ZR + "-Y",  (((float)res.getInteger(R.integer.N3DS_BUTTON_ZR_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_DPAD_UP + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_UP_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_DPAD_UP + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_UP_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_L + "-X", (((float)res.getInteger(R.integer.N3DS_TRIGGER_L_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_L + "-Y", (((float)res.getInteger(R.integer.N3DS_TRIGGER_L_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_R + "-X", (((float)res.getInteger(R.integer.N3DS_TRIGGER_R_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_TRIGGER_R + "-Y", (((float)res.getInteger(R.integer.N3DS_TRIGGER_R_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_START + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_START_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_START + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_START_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_SELECT + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_SELECT_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_SELECT + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_SELECT_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_HOME + "-X", (((float)res.getInteger(R.integer.N3DS_BUTTON_HOME_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_BUTTON_HOME + "-Y", (((float)res.getInteger(R.integer.N3DS_BUTTON_HOME_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_C + "-X", (((float)res.getInteger(R.integer.N3DS_STICK_C_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_C + "-Y", (((float)res.getInteger(R.integer.N3DS_STICK_C_Y) / 1000) * maxY));
+        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_LEFT + "-X", (((float)res.getInteger(R.integer.N3DS_STICK_MAIN_X) / 1000) * maxX));
+        sPrefsEditor.putFloat(ButtonType.N3DS_STICK_LEFT + "-Y", (((float)res.getInteger(R.integer.N3DS_STICK_MAIN_Y) / 1000) * maxY));
+        // We want to commit right away, otherwise the overlay could load before this is saved.
+        sPrefsEditor.commit();
+    }
   public boolean isInEditMode()
   {
     return mIsInEditMode;

--- a/app/src/main/java/org/citra/citra_android/ui/main/TvMainActivity.java
+++ b/app/src/main/java/org/citra/citra_android/ui/main/TvMainActivity.java
@@ -73,7 +73,7 @@ public final class TvMainActivity extends FragmentActivity implements MainView
 
     // Set display parameters for the BrowseFragment
     mBrowseFragment.setHeadersState(BrowseFragment.HEADERS_ENABLED);
-    mBrowseFragment.setBrandColor(ContextCompat.getColor(this, R.color.dolphin_blue_dark));
+    mBrowseFragment.setBrandColor(ContextCompat.getColor(this, R.color.citra_orange_dark));
     buildRowsAdapter();
 
     mBrowseFragment.setOnItemViewClickedListener(

--- a/app/src/main/res/color/button_text_color.xml
+++ b/app/src/main/res/color/button_text_color.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:color="@color/dolphin_blue_dark"
+        android:color="@color/citra_orange_dark"
         android:state_focused="true"/>
     <item
         android:color="@android:color/white"/>

--- a/app/src/main/res/drawable/tv_card_background_gamecube.xml
+++ b/app/src/main/res/drawable/tv_card_background_gamecube.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:state_selected="true"
-        android:drawable="@color/dolphin_accent_gamecube" />
+        android:drawable="@color/citra_accent" />
     <item
         android:drawable="@color/tv_card_unselected" />
 </selector>

--- a/app/src/main/res/layout/activity_add_directory.xml
+++ b/app/src/main/res/layout/activity_add_directory.xml
@@ -9,7 +9,7 @@
         android:id="@+id/toolbar_folder_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/dolphin_blue"
+        android:background="@color/citra_orange"
         android:minHeight="?android:attr/actionBarSize"
         android:theme="@android:style/ThemeOverlay.Material.Dark.ActionBar"
         android:elevation="6dp"/>

--- a/app/src/main/res/layout/fragment_emulation.xml
+++ b/app/src/main/res/layout/fragment_emulation.xml
@@ -38,7 +38,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:padding="@dimen/spacing_small"
-        android:background="@color/dolphin_blue"
+        android:background="@color/citra_orange"
         android:textColor="@color/lb_tv_white"
         android:text="@string/emulation_done"
         android:visibility="gone"/>

--- a/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -4,7 +4,7 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
-              android:background="@color/dolphin_blue_dark"
+              android:background="@color/citra_orange_dark"
               tools:layout_width="250dp">
 
     <TextView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <color name="dolphin_blue">#2196f3</color>
-    <color name="dolphin_blue_dark">#1976d2</color>
-
     <color name="citra_orange">#fec303</color>
     <color name="citra_orange_dark">#fe8a03</color>
+    <color name="citra_accent">#c77413</color>
 
     <color name="dolphin_accent_wii">#9e9e9e</color>
     <color name="dolphin_accent_wiiware">#2979ff</color>
-    <color name="dolphin_accent_gamecube">#651fff</color>
 
     <color name="circle_grey">#bdbdbd</color>
 

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,4 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="game_grid_columns">1</integer>
+        <!-- Default N3DS landscape layout -->
+    <integer name="N3DS_BUTTON_A_X">930</integer>
+    <integer name="N3DS_BUTTON_A_Y">540</integer>
+    <integer name="N3DS_BUTTON_B_X">870</integer>
+    <integer name="N3DS_BUTTON_B_Y">640</integer>
+    <integer name="N3DS_BUTTON_X_X">870</integer>
+    <integer name="N3DS_BUTTON_X_Y">440</integer>
+    <integer name="N3DS_BUTTON_Y_X">810</integer>
+    <integer name="N3DS_BUTTON_Y_Y">540</integer>
+    <integer name="N3DS_BUTTON_UP_X">18</integer>
+    <integer name="N3DS_BUTTON_UP_Y">450</integer>
+    <integer name="N3DS_TRIGGER_L_X">13</integer>
+    <integer name="N3DS_TRIGGER_L_Y">180</integer>
+    <integer name="N3DS_BUTTON_ZL_X">13</integer>
+    <integer name="N3DS_BUTTON_ZL_Y">0</integer>
+    <integer name="N3DS_TRIGGER_R_X">845</integer>
+    <integer name="N3DS_TRIGGER_R_Y">180</integer>
+    <integer name="N3DS_BUTTON_ZR_X">845</integer>
+    <integer name="N3DS_BUTTON_ZR_Y">0</integer>
+    <integer name="N3DS_STICK_C_X">665</integer>
+    <integer name="N3DS_STICK_C_Y">650</integer>
+    <integer name="N3DS_STICK_MAIN_X">170</integer>
+    <integer name="N3DS_STICK_MAIN_Y">650</integer>
+    <integer name="N3DS_BUTTON_START_X">520</integer>
+    <integer name="N3DS_BUTTON_START_Y">850</integer>
+    <integer name="N3DS_BUTTON_SELECT_X">480</integer>
+    <integer name="N3DS_BUTTON_SELECT_Y">850</integer>
+    <integer name="N3DS_BUTTON_HOME_X">440</integer>
+    <integer name="N3DS_BUTTON_HOME_Y">850</integer>
+    
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,9 +5,9 @@
     <style name="DolphinBase" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Main theme colors -->
         <!-- Branding color for the app bar -->
-        <item name="colorPrimary">@color/dolphin_blue</item>
+        <item name="colorPrimary">@color/citra_orange</item>
         <!-- Darker variant for the status bar and contextual app bars -->
-        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
+        <item name="colorPrimaryDark">@color/citra_orange_dark</item>
 
         <!-- Enable window content transitions -->
         <item name="android:windowContentTransitions">true</item>
@@ -19,8 +19,8 @@
 
     <!-- Same as above, but use default action bar, and mandate margins. -->
     <style name="DolphinSettingsBase" parent="Theme.AppCompat.Light.DarkActionBar">
-        <item name="colorPrimary">@color/dolphin_blue</item>
-        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
+        <item name="colorPrimary">@color/citra_orange</item>
+        <item name="colorPrimaryDark">@color/citra_orange_dark</item>
     </style>
 
     <!-- Inherit from the Base Dolphin Theme -->
@@ -30,7 +30,7 @@
     </style>
 
     <style name="DolphinGamecube" parent="DolphinBase">
-        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+        <item name="colorAccent">@color/citra_accent</item>
     </style>
 
     <style name="DolphinWiiware" parent="DolphinBase">
@@ -43,7 +43,7 @@
     </style>
 
     <style name="DolphinSettingsGamecube" parent="DolphinSettingsBase">
-        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+        <item name="colorAccent">@color/citra_accent</item>
     </style>
 
     <style name="DolphinSettingsWiiware" parent="DolphinSettingsBase">
@@ -56,8 +56,8 @@
     <!-- Inherit from the Base Dolphin Dialog Theme -->
 
     <style name="DolphinEmulationBase" parent="Theme.AppCompat.Light.DarkActionBar">
-        <item name="colorPrimary">@color/dolphin_blue</item>
-        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
+        <item name="colorPrimary">@color/citra_orange</item>
+        <item name="colorPrimaryDark">@color/citra_orange_dark</item>
         <item name="android:windowTranslucentNavigation">true</item>
 
         <item name="android:windowBackground">@android:color/black</item>
@@ -74,7 +74,7 @@
     </style>
 
     <style name="DolphinEmulationGamecube" parent="DolphinEmulationBase">
-        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+        <item name="colorAccent">@color/citra_accent</item>
     </style>
 
     <style name="DolphinEmulationWiiware" parent="DolphinEmulationBase">
@@ -82,8 +82,8 @@
     </style>
 
     <style name="DolphinEmulationTvBase" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="colorPrimary">@color/dolphin_blue</item>
-        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
+        <item name="colorPrimary">@color/citra_orange</item>
+        <item name="colorPrimaryDark">@color/citra_orange_dark</item>
         <item name="android:windowTranslucentNavigation">true</item>
 
         <item name="android:windowBackground">@android:color/black</item>
@@ -100,7 +100,7 @@
     </style>
 
     <style name="DolphinEmulationTvGamecube" parent="DolphinEmulationTvBase">
-        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+        <item name="colorAccent">@color/citra_accent</item>
     </style>
 
     <style name="DolphinEmulationTvWiiware" parent="DolphinEmulationTvBase">
@@ -114,8 +114,8 @@
 
     <!-- Android TV Themes -->
     <style name="DolphinTvBase" parent="Theme.Leanback.Browse">
-        <item name="colorPrimary">@color/dolphin_blue</item>
-        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
+        <item name="colorPrimary">@color/citra_orange</item>
+        <item name="colorPrimaryDark">@color/citra_orange_dark</item>
 
         <!-- Enable window content transitions -->
         <item name="android:windowContentTransitions">true</item>
@@ -124,7 +124,7 @@
     </style>
 
     <style name="DolphinTvGamecube" parent="DolphinTvBase">
-        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+        <item name="colorAccent">@color/citra_accent</item>
         <item name="browseTitleViewLayout">@layout/titleview</item>
     </style>
 
@@ -147,9 +147,9 @@
 
     <!-- You can also inherit from NNF_BaseTheme.Light -->
     <style name="FilePickerTheme" parent="NNF_BaseTheme.Light">
-        <item name="colorPrimary">@color/dolphin_blue</item>
-        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
-        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+        <item name="colorPrimary">@color/citra_orange</item>
+        <item name="colorPrimaryDark">@color/citra_orange_dark</item>
+        <item name="colorAccent">@color/citra_accent</item>
 
         <!--&lt;!&ndash; Setting a divider is entirely optional &ndash;&gt;-->
         <item name="nnf_list_item_divider">?android:attr/listDivider</item>
@@ -163,9 +163,9 @@
     </style>
 
     <style name="FilePickerAlertDialogTheme" parent="Theme.AppCompat.Dialog.Alert">
-        <item name="colorPrimary">@color/dolphin_blue</item>
-        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
-        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+        <item name="colorPrimary">@color/citra_orange</item>
+        <item name="colorPrimaryDark">@color/citra_orange_dark</item>
+        <item name="colorAccent">@color/citra_accent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
default button overlay BUT just for landscape mode, portrait mode default overlay can be added later just like this but with different Integers and overlay. Somthing Like this : https://github.com/dolphin-emu/dolphin/pull/7405
Although adding portrait buttons overaly is very wrong in my opinion, because user don't have access to the second touch screen, because it's covered with buttons. 
Instead, my recommendation is that we start the emulation in landscape mode and lock it in that orientation and when user exits the emulation, unlock the screen rotation 
New landscape buttons overlay : 
![screenshot_20181101-140204](https://user-images.githubusercontent.com/26696487/47846951-f6545400-ddde-11e8-88d2-c0b2a01b77e9.jpg)
Also, Changed app's Color Theme To Match Citra's.

